### PR TITLE
docs: Add missing parenthesis

### DIFF
--- a/guide/src/macros/impl.md
+++ b/guide/src/macros/impl.md
@@ -38,7 +38,7 @@ be named `self_`. This can also be used to return a reference to `$this`.
 
 The rest of the options are passed as separate attributes:
 
-- `#[php(defaults(i = 5, b = "hello")]` - Sets the default value for parameter(s).
+- `#[php(defaults(i = 5, b = "hello"))]` - Sets the default value for parameter(s).
 - `#[php(optional = i)]` - Sets the first optional parameter. Note that this also sets
   the remaining parameters as optional, so all optional parameters must be a
   variant of `Option<T>`.


### PR DESCRIPTION
## Description

This PR fixes a typo in the guide - I copy-pasted the code into my project and noted that there is a missing parenthesis in the example.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests that prove my code works as expected.
- [ ] I have added documentation if applicable.
- [ ] I have added a [migration guide](../CONTRIBUTING.md#breaking-changes) if applicable.


Thanks!